### PR TITLE
Add DescribeOrderDetailInfo to SDK

### DIFF
--- a/services/ubilling/client.go
+++ b/services/ubilling/client.go
@@ -1,0 +1,19 @@
+package ubillings
+
+import (
+	"github.com/ucloud/ucloud-sdk-go/ucloud"
+	"github.com/ucloud/ucloud-sdk-go/ucloud/auth"
+)
+
+// UHostClient is the client of UHost
+type UBillingClient struct {
+	client *ucloud.Client
+}
+
+// NewClient will return a instance of UHostClient
+func NewClient(config *ucloud.Config, credential *auth.Credential) *UBillingClient {
+	client := ucloud.NewClient(config, credential)
+	return &UBillingClient{
+		client: client,
+	}
+}

--- a/services/ubilling/describe_order_detail_info.go
+++ b/services/ubilling/describe_order_detail_info.go
@@ -1,0 +1,68 @@
+package ubillings
+
+import (
+	"github.com/ucloud/ucloud-sdk-go/ucloud/request"
+	"github.com/ucloud/ucloud-sdk-go/ucloud/response"
+)
+
+type DescribeUBillingRequest struct {
+	request.CommonBase
+
+	//开始时间，UNIX time format
+	BeginTime int64 `required:"true"`
+	//结束时间，时间跨度不超过3个月
+	EndTime int64 `required:"true"`
+	//产品类型，默认全部的产品类型
+	ResourceTypes string `required:"false"`
+	//订单类型，默认全部订单类型
+	OrderTypes string `required:"false"`
+	//付费类型，默认全部的计费方式
+	ChargeTypes string
+	//订单状态，默认选中全部的可选参数
+	OrderStates string `required:"false"`
+	//是否开过发票，默认选中全部的可选参数
+	Invoiceds string `required:"false"`
+	//返回数据长度，默认25
+	Limit int `required:"false"`
+	//数据偏移量，默认0
+	Offset int `required:"false"`
+	//资源ID
+	ResourceIDs string `required:"false"`
+	//交易单号，该字段存在时，可以不传BeginTime和EndTime
+	TradeNos string `required:"false"`
+	//true表示查询全部，默认全部，其他选项按照项目自查询
+	QueryAll string `required:"false"`
+
+}
+
+type DescribeUBillingResponse struct {
+	response.CommonBase
+
+	//json格式的订单信息
+	OrderInfo []OrderInfos
+
+}
+
+func (c *UBillingClient) NewDescribeOrderDetailInfoRequest() *DescribeUBillingRequest {
+	req := &DescribeUBillingRequest{}
+
+	//设置client请求配置config
+	c.client.SetupRequest(req)
+
+	//设置默认重试
+	req.SetRetryable(true)
+	req.SetProjectId("org-04qk4t")
+	return req
+}
+
+func (c *UBillingClient) DescribeOrderDetailInfo(req *DescribeUBillingRequest) (*DescribeUBillingResponse, error) {
+	var err error
+	var res DescribeUBillingResponse
+
+	err = c.client.InvokeAction("DescribeOrderDetailInfo", req, &res)
+	if err != nil {
+		return &res, err
+	}
+
+	return &res, nil
+}

--- a/services/ubilling/types_ubillings_order_infos.go
+++ b/services/ubilling/types_ubillings_order_infos.go
@@ -1,0 +1,33 @@
+package ubillings
+
+type OrderInfos struct {
+	OrderNo string  `json:"OrderNo"`
+	ReourceId string
+	OrderType string
+	ChargeType string
+	ResourceId string
+	ResourceTag string
+	OrderState string
+	CreateTime string
+	Amount string //订单总金额
+	AmountReal string //现金账户金额
+	AmountFree string //赠送账户金额（元）
+	AmountCoupon string //优惠金额
+	CouponCode string //如果AmountCoupon不为0，显示代金券号码
+	ResourceType string
+	UpdateTime string
+	Quantity int64 //计费周期数
+	Count int64 //资源数量
+	Invoiced string //是否开过发票
+	StartTime string //开始时间
+	EndTime string //结束时间
+	OrderDetails []OrderDetail
+	RegionId string //region
+	TradeNo string //交易号
+
+}
+
+type OrderDetail struct {
+	ProductName string
+	Value string
+}

--- a/services/ubilling/types_ubillings_resource_tag.go
+++ b/services/ubilling/types_ubillings_resource_tag.go
@@ -1,0 +1,18 @@
+package ubillings
+
+type ResourceTag struct {
+	KeyId string //标识名,见下表
+	Value string //标识信息
+}
+
+
+
+
+/*KeyId	Description
+name	名称(eg. “hello_vm”)
+hostname	主机名(eg. “uhost-0zjhzf”)
+domain	域名(高防, eg. “www.qq.com”)
+private_ip	内网IP
+public_ip	外网IP
+remark	备注
+tag	标签 */


### PR DESCRIPTION
Add DescribeOrderDetailInfo  to SDK, for example:

 `func loadConfig()(*ucloud.Config, *auth.Credential){
	cfg := ucloud.NewConfig()

	credential := auth.NewCredential()
	credential.PrivateKey ="privateKey"
	credential.PublicKey = "publicKey"

	return &cfg, &credential
}

func main()  {
	cfg, credential := loadConfig()
	ubillingClient := ubillings.NewClient(cfg, credential)
	
	req := ubillingClient.NewDescribeOrderDetailInfoRequest()
	req.BeginTime = 1539417292
	req.EndTime = 1542095692
	req.SetRegion("kr-seoul-01")
	req.Limit= 100
	
	
	newUBilling, err := ubillingClient.DescribeOrderDetailInfo(req)
	
	if err != nil {
		fmt.Println(err)
	}
	
	fmt.Println(newUBilling)
}`