### PR TITLE
fix typo for expected/excepted

### DIFF
--- a/examples/logging/main.go
+++ b/examples/logging/main.go
@@ -26,13 +26,13 @@ func main() {
 
 	uhostClient := uhost.NewClient(&cfg, &credential)
 
-	// excepted logging
+	// included logging
 	req1 := uhostClient.NewDescribeUHostInstanceRequest()
 	req1.Region = ucloud.String(region)
 
 	uhostClient.DescribeUHostInstance(req1)
 
-	// unexcepted logging
+	// excepted logging
 	cfg.SetActionLevel("DescribeImage", log.WarnLevel)
 	req2 := uhostClient.NewDescribeImageRequest()
 	req2.Region = ucloud.String(region)

--- a/external/set.go
+++ b/external/set.go
@@ -30,7 +30,7 @@ type set struct {
 	idMap  map[int]interface{}
 }
 
-// newSet will excepted a list, reserving only one item with same id and return a set-collection
+// newSet will expected a list, reserving only one item with same id and return a set-collection
 func newSet(idFunc setIDFunc, vL []interface{}) *set {
 	s := &set{
 		idMap:  make(map[int]interface{}, len(vL)),

--- a/external/shared_config.go
+++ b/external/shared_config.go
@@ -26,7 +26,7 @@ func DefaultSharedCredentialsFile() string {
 // LoadUCloudConfigFile will load ucloud client config from config file
 func LoadUCloudConfigFile(cfgFile, profile string) (*ucloud.Config, error) {
 	if len(profile) == 0 {
-		return nil, fmt.Errorf("excepted ucloud named profile is not empty")
+		return nil, fmt.Errorf("expected ucloud named profile is not empty")
 	}
 
 	cfgMaps, err := loadConfigFile(cfgFile)
@@ -41,7 +41,7 @@ func LoadUCloudConfigFile(cfgFile, profile string) (*ucloud.Config, error) {
 // LoadUCloudCredentialFile will load ucloud credential config from config file
 func LoadUCloudCredentialFile(credFile, profile string) (*auth.Credential, error) {
 	if len(profile) == 0 {
-		return nil, fmt.Errorf("excepted ucloud named profile is not empty")
+		return nil, fmt.Errorf("expected ucloud named profile is not empty")
 	}
 
 	credMaps, err := loadCredFile(credFile)

--- a/ucloud/client_test.go
+++ b/ucloud/client_test.go
@@ -128,11 +128,11 @@ func Test_errorHandler(t *testing.T) {
 		step func() error
 	}{
 		{
-			name: "unexcepted error",
+			name: "unexpected error",
 			step: func() error {
-				_, err := errorHandler(client, req, resp, errors.New("unexcepted error"))
+				_, err := errorHandler(client, req, resp, errors.New("unexpected error"))
 				if uErr, ok := err.(uerr.ClientError); !ok || uErr.Name() != uerr.ErrSendRequest {
-					return errors.New("unexcepted error should be convert to unknown client error")
+					return errors.New("unexpected error should be convert to unknown client error")
 				}
 				return nil
 			},

--- a/ucloud/error/client_error.go
+++ b/ucloud/error/client_error.go
@@ -18,8 +18,8 @@ var (
 	// ErrNetwork is retryable
 	ErrNetwork = "client.NetworkError"
 
-	// ErrUnexcepted is the error for any unexcepted error
-	ErrUnexcepted = "client.UnexceptedError"
+	// ErrUnexpected is the error for any unexpected error
+	ErrUnexpected = "client.UnexpectedError"
 )
 
 // ClientError is the ucloud common errorfor server response

--- a/ucloud/error/error.go
+++ b/ucloud/error/error.go
@@ -38,7 +38,7 @@ func NewRetryableError(err error) Error {
 		return e
 	}
 
-	e := NewClientError(ErrUnexcepted, err)
+	e := NewClientError(ErrUnexpected, err)
 	e.retryable = true
 	return e
 }
@@ -55,7 +55,7 @@ func NewNonRetryableError(err error) Error {
 		return e
 	}
 
-	e := NewClientError(ErrUnexcepted, err)
+	e := NewClientError(ErrUnexpected, err)
 	e.retryable = false
 	return e
 }

--- a/ucloud/error/error_test.go
+++ b/ucloud/error/error_test.go
@@ -9,9 +9,9 @@ import (
 
 func TestClientError(t *testing.T) {
 	originErr := errors.New("o")
-	err := NewClientError(ErrUnexcepted, originErr)
+	err := NewClientError(ErrUnexpected, originErr)
 
-	assert.Equal(t, err.Name(), ErrUnexcepted)
+	assert.Equal(t, err.Name(), ErrUnexpected)
 	assert.Equal(t, err.Code(), -1)
 	assert.Equal(t, err.OriginError(), originErr)
 	assert.Equal(t, err.Retryable(), false)
@@ -39,7 +39,7 @@ func TestServerError(t *testing.T) {
 func TestRetryableError(t *testing.T) {
 	err := NewRetryableError(errors.New("o"))
 
-	assert.Equal(t, err.Name(), ErrUnexcepted)
+	assert.Equal(t, err.Name(), ErrUnexpected)
 	assert.Equal(t, err.Code(), -1)
 	assert.Error(t, err.OriginError())
 	assert.Equal(t, err.Retryable(), true)


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->

BUG FIXES:

- **(BREAK CHANGES)** Rename `ErrUnexcepted` to `ErrUnexpected`.
