### PR TITLE
add u-timestamp-ms request header for tracing e2e latency

### DIFF
--- a/private/protocol/http/defaults.go
+++ b/private/protocol/http/defaults.go
@@ -12,6 +12,7 @@ const (
 const (
 	HeaderNameContentType = "Content-Type"
 	HeaderNameUserAgent   = "User-Agent"
+	HeaderUTimestampMs    = "U-Timestamp-Ms"
 )
 
 // DefaultHeaders defined default http headers

--- a/ucloud/marshaler.go
+++ b/ucloud/marshaler.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"runtime"
+	"strconv"
 	"strings"
 
 	uerr "github.com/ucloud/ucloud-sdk-go/ucloud/error"
@@ -73,6 +74,7 @@ func (c *Client) buildHTTPRequest(req request.Common) (*http.HttpRequest, error)
 		runtime.Version(), version.Version, product, c.GetConfig().UserAgent,
 	)
 	_ = httpReq.SetHeader(http.HeaderNameUserAgent, strings.TrimSpace(ua))
+	_ = httpReq.SetHeader(http.HeaderUTimestampMs, strconv.FormatInt(req.GetRequestTime().UnixNano()/1000000, 10))
 	return httpReq, nil
 }
 


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->

ENHANCEMENTS:
- add u-timestamp-ms request header for tracing e2e latency
