### PR TITLE
fix: 修复监控指标数据 Tag 字段类型错误

### DIFF
--- a/services/cloudwatch/models.go
+++ b/services/cloudwatch/models.go
@@ -392,7 +392,7 @@ type MetricResult struct {
 	ResourceId string
 
 	// TagMap是一个对象，key和value均为字符串。TagMap返回当前series的所有的tag的key和value。
-	TagMap string
+	TagMap map[string]string
 
 	//
 	Values []MetricSample
@@ -410,7 +410,7 @@ type QueryMetricDataRespItem struct {
 	Results []MetricResult
 
 	// 指标查询结果的所有tag的key和对应的所有value数组。Tags格式为，key为tagkey字符串，value为tagValue的字符串数组。
-	Tags string
+	Tags map[string][]string
 }
 
 /*


### PR DESCRIPTION
<!--- Information about referencing Github Issues: https://help.github.com/articles/basic-writing-and-formatting-syntax/#referencing-issues-and-pull-requests --->

FEATURES:

ENHANCEMENTS:

BUG FIXES: 修复监控指标数据 Tag 字段类型错误，原先的 `TagMap` 和 `Tag` 字段的类型与其注释和返回的内容不匹配，如下图：

<img width="3004" height="1157" alt="image" src="https://github.com/user-attachments/assets/a6a558c9-1829-463b-aab9-4afed4d9602d" />

导致我在调用监控接口时 SDK 报错，我的项目现在必须创建 vendor 目录并手动修改源码，希望能合并解决这个问题。


