### PR TITLE
fix(test): make TestClientTimeout independent of httpbin.org

### DIFF
--- a/ucloud/client_test.go
+++ b/ucloud/client_test.go
@@ -2,6 +2,7 @@ package ucloud
 
 import (
 	stdhttp "net/http"
+	"net/http/httptest"
 	"os"
 	"testing"
 	"time"
@@ -33,12 +34,21 @@ func testSetup() {}
 func testTeardown() {}
 
 func TestClientTimeout(t *testing.T) {
+	// the handler never writes a response, so every attempt (including retries)
+	// can only end in the client's own timeout
+	blocked := make(chan struct{})
+	server := httptest.NewServer(stdhttp.HandlerFunc(func(w stdhttp.ResponseWriter, r *stdhttp.Request) {
+		<-blocked
+	}))
+	defer server.Close()
+	defer close(blocked) // release the handlers first, so Close does not wait on them
+
 	req := &MockRequest{}
 	resp := &MockResponse{}
 
 	client := newTestClient()
-	client.config.BaseUrl = "https://httpbin.org/delay/2"
-	client.config.Timeout = 1 * time.Second
+	client.config.BaseUrl = server.URL
+	client.config.Timeout = 200 * time.Millisecond
 	client.config.MaxRetries = 1
 	client.SetupRequest(req)
 


### PR DESCRIPTION
## Problem

`TestClientTimeout` sets `BaseUrl` to `https://httpbin.org/delay/2` and relies on that
endpoint being slower than the 1s client timeout:

```go
client.config.BaseUrl = "https://httpbin.org/delay/2"
client.config.Timeout = 1 * time.Second
```

httpbin.org now frequently answers **503 in ~1.3s** instead of delaying. When that
happens the client receives a real HTTP response rather than timing out, so `err` is a
`server.HTTPStatusError`, not a `uerr.ClientError`. The type assertion on line 47 fails,
`uErr` stays a zero value, and the `Name()` comparison below it fails too:

```
--- FAIL: TestClientTimeout (1.30s)
    client_test.go:47: Error: Should be true
    client_test.go:48: expected: "" / actual: "client.NetworkError"
```

Probing the endpoint three times just now returned `200 (4.7s)`, `503 (1.2s)`,
`503 (1.5s)` — so this is not a rare flake, the test fails more often than it passes.

## Fix

Replace the external dependency with a local `httptest` server whose handler blocks and
never writes a response, so every attempt (including the retry) can only end in the
client's own timeout. The timeout drops to 200ms since there is no real network round
trip involved. The assertions are unchanged — the test still verifies that a timeout
surfaces as `uerr.ErrNetwork` with the expected retry counts.

## Verification

```
gofmt -l ucloud/client_test.go   # clean
go vet ./ucloud/                 # clean
go test -run '^TestClientTimeout$' -count=3 ./ucloud/   # ok
go test -cover ./ucloud/...      # all 12 packages pass, ucloud at 96.2%
```

The test no longer touches the network, so it also works in offline/restricted CI
environments.